### PR TITLE
Update MFRC522.cpp

### DIFF
--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -1628,6 +1628,8 @@ bool MFRC522::MIFARE_UnbrickUidSector(bool logErrors) {
         }
         return false;
     }
+	
+    return true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes a compile issue in Particle Web IDE: *lib/MFRC522/MFRC522.cpp:1631:1: control reaches end of non-void function [-Werror=return-type]*. Added "return true;" at end of function.